### PR TITLE
feat(COFF-3): create Global Response, ExceptionHandler

### DIFF
--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -1,0 +1,59 @@
+name: Makefile CI
+
+on:
+  push:
+    branches: [ "main", "develop" ]
+  pull_request:
+    branches: [ "main", "develop" ]
+  workflow_dispatch:
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.8
+
+  build:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Create .env file
+        run: |
+          touch ./env
+          echo "${{ secrets.ENV }}" > ./.env
+        shell: bash
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.8
+
+      - name: Run test code
+        run: make test
+
+      - name: Run build
+        run: make build
+
+      - name: Run docker
+        run: make up

--- a/src/main/java/com/muhwaran/coff/global/common/response/GlobalResponse.java
+++ b/src/main/java/com/muhwaran/coff/global/common/response/GlobalResponse.java
@@ -1,0 +1,15 @@
+package com.muhwaran.coff.global.common.response;
+
+import java.time.LocalDateTime;
+
+import com.muhwaran.coff.global.error.ErrorResponse;
+
+public record GlobalResponse(boolean isSuccess, int status, Object data, LocalDateTime timestamp) {
+	public static GlobalResponse ok(int status, Object data) {
+		return new GlobalResponse(true, status, data, LocalDateTime.now());
+	}
+
+	public static GlobalResponse error(int status, ErrorResponse errorResponse) {
+		return new GlobalResponse(false, status, errorResponse, LocalDateTime.now());
+	}
+}

--- a/src/main/java/com/muhwaran/coff/global/common/response/GlobalResponseAdvice.java
+++ b/src/main/java/com/muhwaran/coff/global/common/response/GlobalResponseAdvice.java
@@ -1,0 +1,47 @@
+package com.muhwaran.coff.global.common.response;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+@RestControllerAdvice(basePackages = "muhwaran.coff")
+public class GlobalResponseAdvice implements ResponseBodyAdvice<Object> {
+	@Override
+	public boolean supports(
+		MethodParameter returnType,
+		Class<? extends HttpMessageConverter<?>> converterType
+	) {
+		return true;
+	}
+
+	@Override
+	public Object beforeBodyWrite(
+		Object body,
+		MethodParameter returnType,
+		MediaType selectedContentType,
+		Class<? extends HttpMessageConverter<?>> selectedConverterType,
+		ServerHttpRequest request,
+		ServerHttpResponse response
+	) {
+		ServletServerHttpResponse servletServerHttpResponse = (ServletServerHttpResponse)response;
+		HttpServletResponse httpServletResponse = servletServerHttpResponse.getServletResponse();
+		int status = httpServletResponse.getStatus();
+		HttpStatus resolve = HttpStatus.resolve(status);
+
+		if (resolve == null || body instanceof String) {
+			return body;
+		}
+		if (resolve.is2xxSuccessful()) {
+			return GlobalResponse.ok(status, body);
+		}
+		return body;
+	}
+}

--- a/src/main/java/com/muhwaran/coff/global/error/CustomException.java
+++ b/src/main/java/com/muhwaran/coff/global/error/CustomException.java
@@ -1,0 +1,13 @@
+package com.muhwaran.coff.global.error;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+	private final ErrorCode errorCode;
+
+	public CustomException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/muhwaran/coff/global/error/ErrorCode.java
+++ b/src/main/java/com/muhwaran/coff/global/error/ErrorCode.java
@@ -1,0 +1,25 @@
+package com.muhwaran.coff.global.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+	// Common
+	METHOD_ARGUMENT_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 method 인자 입니다."),
+	METHOD_NOT_SUPPORTED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP method 입니다."),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다. 관리자에게 문의해주세요."),
+	HTTP_MESSAGE_NOT_READABLE(HttpStatus.BAD_REQUEST, "잘못된 요청 메시지 형식입니다."),
+	QUERY_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "올바르지 않은 쿼리 타입 입니다."),
+	QUERY_PARAM_INVALID(HttpStatus.BAD_REQUEST, "올바르지 않은 쿼리 파라미터 값입니다."),
+	QUERY_PARAM_NOT_FOUND(HttpStatus.BAD_REQUEST, "쿼리 파라미터가 존재하지 않습니다."),
+
+	// User
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/com/muhwaran/coff/global/error/ErrorResponse.java
+++ b/src/main/java/com/muhwaran/coff/global/error/ErrorResponse.java
@@ -1,0 +1,7 @@
+package com.muhwaran.coff.global.error;
+
+public record ErrorResponse(String className, String message) {
+	public static ErrorResponse of(String className, String message) {
+		return new ErrorResponse(className, message);
+	}
+}

--- a/src/main/java/com/muhwaran/coff/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/muhwaran/coff/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,151 @@
+package com.muhwaran.coff.global.error;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import com.muhwaran.coff.global.common.response.GlobalResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+	private static final String ERROR_MESSAGE_DELIMITER = " ";
+
+	@Override
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(
+		MethodArgumentNotValidException ex,
+		HttpHeaders headers,
+		HttpStatusCode statusCode,
+		WebRequest request
+	) {
+		log.error("MethodArgumentNotValid : {}", ex.getMessage(), ex);
+
+		// 모든 오류 메시지를 수집
+		Map<String, String> errors = new HashMap<>();
+		ex.getBindingResult().getFieldErrors().forEach(fieldError -> {
+			String fieldName = fieldError.getField();
+			String errorMessage = fieldError.getDefaultMessage();
+			errors.put(fieldName, errorMessage);
+		});
+
+		final ErrorCode errorCode = ErrorCode.METHOD_ARGUMENT_INVALID;
+		final String errorMessage = String.join(ERROR_MESSAGE_DELIMITER, errorCode.getMessage(), errors.toString());
+		final ErrorResponse errorResponse = ErrorResponse.of(ex.getClass().getSimpleName(), errorMessage);
+		final GlobalResponse globalResponse = GlobalResponse.error(errorCode.getHttpStatus().value(), errorResponse);
+		return ResponseEntity.status(errorCode.getHttpStatus()).body(globalResponse);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(
+		HttpRequestMethodNotSupportedException ex,
+		HttpHeaders headers,
+		HttpStatusCode status,
+		WebRequest request
+	) {
+		log.error("HttpRequestMethodNotSupported : {}", ex.getMessage(), ex);
+		final ErrorCode errorCode = ErrorCode.METHOD_NOT_SUPPORTED;
+		return createErrorResponseEntity(ex, errorCode);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleHandlerMethodValidationException(HandlerMethodValidationException ex,
+		HttpHeaders headers,
+		HttpStatusCode status,
+		WebRequest request
+	) {
+		log.error("HandlerMethodValidationException : {}", ex.getMessage(), ex);
+		final ErrorCode errorCode = ErrorCode.QUERY_PARAM_INVALID;
+		return createErrorResponseEntity(ex, errorCode);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleMissingServletRequestParameter(MissingServletRequestParameterException ex,
+		HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+		log.error("MissingServletRequestParameter : {}", ex.getMessage(), ex);
+		final ErrorCode errorCode = ErrorCode.QUERY_PARAM_NOT_FOUND;
+		return createErrorResponseEntity(ex, errorCode);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleExceptionInternal(
+		Exception ex,
+		Object body,
+		HttpHeaders headers,
+		HttpStatusCode statusCode,
+		WebRequest request
+	) {
+		log.error("ExceptionInternal : {}", ex.getMessage(), ex);
+		final ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+		return createErrorResponseEntity(ex, errorCode);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleHttpMessageNotReadable(
+		HttpMessageNotReadableException ex,
+		HttpHeaders headers,
+		HttpStatusCode status,
+		WebRequest request
+	) {
+		log.error("HttpMessageNotReadable : {}", ex.getMessage(), ex);
+		final ErrorCode errorCode = ErrorCode.HTTP_MESSAGE_NOT_READABLE;
+		return createErrorResponseEntity(ex, errorCode);
+	}
+
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<Object> handleCustomException(CustomException ex) {
+		log.error("CustomException : {}", ex.getMessage(), ex);
+		final ErrorCode errorCode = ex.getErrorCode();
+		return createErrorResponseEntity(ex, errorCode);
+	}
+
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<Object> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException ex) {
+		log.error("MethodArgumentTypeMismatchException : {}", ex.getMessage(), ex);
+		final ErrorCode errorCode = ErrorCode.QUERY_TYPE_MISMATCH;
+		return createErrorResponseEntity(ex, errorCode);
+	}
+
+	@ExceptionHandler(HttpClientErrorException.class)
+	protected ResponseEntity<Object> handleClientErrorException(HttpClientErrorException ex) {
+		log.error("HttpClientError : {}", ex.getMessage(), ex);
+		return createHttpClientErrorResponseEntity(ex);
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<Object> handleException(Exception ex) {
+		log.error("InternalServerError : {}", ex.getMessage(), ex);
+		final ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+		return createErrorResponseEntity(ex, errorCode);
+	}
+
+	private ResponseEntity<Object> createErrorResponseEntity(final Exception ex, final ErrorCode errorCode) {
+		final ErrorResponse errorResponse = ErrorResponse.of(ex.getClass().getSimpleName(), errorCode.getMessage());
+		final GlobalResponse globalResponse = GlobalResponse.error(errorCode.getHttpStatus().value(), errorResponse);
+		return ResponseEntity.status(errorCode.getHttpStatus()).body(globalResponse);
+	}
+
+	private ResponseEntity<Object> createHttpClientErrorResponseEntity(final HttpClientErrorException ex) {
+		final ErrorResponse errorResponse = ErrorResponse.of(ex.getClass().getSimpleName(),
+			ex.getResponseBodyAsString());
+		final GlobalResponse globalResponse = GlobalResponse.error(ex.getStatusCode().value(), errorResponse);
+		return ResponseEntity.status(ex.getStatusCode()).body(globalResponse);
+	}
+}

--- a/src/test/java/com/muhwaran/coff/global/common/response/GlobalResponseAdviceTest.java
+++ b/src/test/java/com/muhwaran/coff/global/common/response/GlobalResponseAdviceTest.java
@@ -1,0 +1,90 @@
+package com.muhwaran.coff.global.common.response;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class GlobalResponseAdviceTest {
+
+	private GlobalResponseAdvice advice;
+
+	@Mock
+	private MethodParameter returnType;
+
+	@Mock
+	private ServerHttpRequest request;
+
+	@Mock
+	private ServletServerHttpResponse response;
+
+	private MockHttpServletResponse servletResponse;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		advice = new GlobalResponseAdvice();
+		servletResponse = new MockHttpServletResponse();
+		when(response.getServletResponse()).thenReturn(servletResponse);
+	}
+
+	@Test
+	void supports_shouldAlwaysReturnTrue() {
+		assertTrue(advice.supports(returnType, null));
+	}
+
+	@Test
+	void beforeBodyWrite_withSuccessStatus_shouldReturnGlobalResponse() {
+		servletResponse.setStatus(HttpStatus.OK.value());
+
+		Object result = advice.beforeBodyWrite(null, returnType, MediaType.APPLICATION_JSON,
+			null, request, response);
+
+		System.out.println("result = " + result);
+		assertInstanceOf(GlobalResponse.class, result);
+		GlobalResponse globalResponse = (GlobalResponse)result;
+		assertEquals(HttpStatus.OK.value(), globalResponse.status());
+	}
+
+	@Test
+	void beforeBodyWrite_withErrorStatus_shouldReturnOriginalBody() {
+		Object body = "에러 메시지";
+		servletResponse.setStatus(HttpStatus.BAD_REQUEST.value());
+
+		Object result = advice.beforeBodyWrite(body, returnType, MediaType.APPLICATION_JSON,
+			null, request, response);
+
+		assertEquals(body, result);
+	}
+
+	@Test
+	void beforeBodyWrite_withStringBody_shouldReturnOriginalBody() {
+		String body = "문자열 본문";
+		servletResponse.setStatus(HttpStatus.OK.value());
+
+		Object result = advice.beforeBodyWrite(body, returnType, MediaType.APPLICATION_JSON,
+			null, request, response);
+
+		assertEquals(body, result);
+	}
+
+	@Test
+	void beforeBodyWrite_withNullHttpStatus_shouldReturnOriginalBody() {
+		Object body = "알 수 없는 상태";
+		servletResponse.setStatus(999); // 존재하지 않는 HTTP 상태 코드
+
+		Object result = advice.beforeBodyWrite(body, returnType, MediaType.APPLICATION_JSON,
+			null, request, response);
+
+		assertEquals(body, result);
+	}
+}


### PR DESCRIPTION
## 📌 연관된 이슈
[COFF-3/Global REsponse 구현](https://muhwaran.atlassian.net/browse/COFF-3)

## 📝 작업 내용
- HTTP 응답발생히 GlobalResponse로 감싸서 반환합니다.
- 예외 발생시 GlobalExceptionHandler에서 감지하여 GlobalResponse로 감써서 반환합니다.
- Github Actions 작업파일 추가

```json
{
  "isSuccess": true,
  "data": {
    "id": 1,
    "profile": "image/test.jpg",
    "name": "testUser",
    "description": "테스트입니다."
  },
  "timestamp": "2024-07-25T08:22:51.041376638"
}
```
위와 같은 예시형태로 응답을 구성합니다.
- `isSuccess`: 응답의 성공여부를 표현합니다. 2xx번을 의미합니다.
- `data`: 응답 데이터가 담기게 됩니다.
- `timestamp`: 응답 발생 시간을 의미합니다.

## 🌳 작업 브랜치명
COFF-3/global-response-구현